### PR TITLE
Revert #19

### DIFF
--- a/src/default.rs
+++ b/src/default.rs
@@ -10,19 +10,18 @@ pub const TERMINAL_TYPE:        &str = "xterm";
 pub mod escape_sequences {
     use getch_rs::Key;
 
-    pub const ESCAPE_SIGNAL_0: Key = Key::Char('~');
-    pub const ESCAPE_SIGNAL_1: Key = Key::Alt('~');
-    pub const EXIT_CHAR_0:     Key = Key::Char('.');
-    pub const EXIT_CHAR_1:     Key = Key::Ctrl('d');
-    pub const SUSPEND:         Key = Key::Ctrl('z');
-    pub const NO_COLOR:        Key = Key::Char('n');
-    pub const TIME_STAMP:      Key = Key::Char('t');
-    pub const INSTEAD_CRLF:    Key = Key::Char('i');
-    pub const HEXDUMP:         Key = Key::Char('h');
-    pub const DEBUG:           Key = Key::Char('d');
-    pub const COMMAND_0:       Key = Key::Char('!');
-    pub const COMMAND_1:       Key = Key::Char('$');
-    pub const HELP:            Key = Key::Char('?');
+    pub const ESCAPE_SIGNAL: Key = Key::Char('~');
+    pub const EXIT_CHAR_0:   Key = Key::Char('.');
+    pub const EXIT_CHAR_1:   Key = Key::Ctrl('d');
+    pub const SUSPEND:       Key = Key::Ctrl('z');
+    pub const NO_COLOR:      Key = Key::Char('n');
+    pub const TIME_STAMP:    Key = Key::Char('t');
+    pub const INSTEAD_CRLF:  Key = Key::Char('i');
+    pub const HEXDUMP:       Key = Key::Char('h');
+    pub const DEBUG:         Key = Key::Char('d');
+    pub const COMMAND_0:     Key = Key::Char('!');
+    pub const COMMAND_1:     Key = Key::Char('$');
+    pub const HELP:          Key = Key::Char('?');
 }
 
 pub fn terminal_type() -> String {

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -449,7 +449,7 @@ where
                 }
 
                 // If the previous character is not a tilde and the current character is a tilde
-                if !last_is_escape_signal && matches!(key, ESCAPE_SIGNAL_0 | ESCAPE_SIGNAL_1) {
+                if !last_is_escape_signal && matches!(key, ESCAPE_SIGNAL) {
                     last_is_escape_signal = true;
                     eprint_flush("~");
                     continue;
@@ -459,7 +459,7 @@ where
                 if last_is_escape_signal {
                     last_is_escape_signal = false;
                     match key {
-                        ESCAPE_SIGNAL_0 | ESCAPE_SIGNAL_1 => {
+                        ESCAPE_SIGNAL => {
                             eprint_flush("\x08");
                         },
                         EXIT_CHAR_0 | EXIT_CHAR_1 => {


### PR DESCRIPTION
Fixes #20 

Since #19 is a squash merge, the change to using "clippy" and "getch-rs" is retained, but the process of making `Alt('~')` an escape sequence is rebated.