### PR TITLE
Fix for shorter if let lifetime

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -335,12 +335,13 @@ fn build_app() -> App<'static, 'static> {
 
 fn get_config_file_path() -> String {
     #[cfg(windows)]
-    return format!("{}/sisterm/config.toml",
-        if let Ok(ref user) = env::var("LOCALAPPDATA") { user } else { "%LOCALAPPDATA%" } );
-
+    const VAR_AND_FALLBACK: (&str, &str) = ("LOCALAPPDATA", "%LOCALAPPDATA%");
     #[cfg(not(windows))]
-    return format!("{}/.config/sisterm/config.toml",
-        if let Ok(ref home) = env::var("HOME") { home } else { "$HOME" } );
+    const VAR_AND_FALLBACK: (&str, &str) = ("HOME", "$HOME");
+    let var = env::var(VAR_AND_FALLBACK.0);
+
+    format!("{}/sisterm/config.toml",
+        if let Ok(ref home) = var { home } else { VAR_AND_FALLBACK.1 })
 }
 
 fn config_file_help_message() -> &'static str {


### PR DESCRIPTION
Context: Rust compiler PR https://github.com/rust-lang/rust/pull/107251 wants to change the lifetime of things inside the `if let` matcher. The PR would break the build of this project (out of only a handful of breakages):

```Rust
error[E0716]: temporary value dropped while borrowed
   --> src/main.rs:343:31
    |
343 |         if let Ok(ref home) = env::var("HOME") { home } else { "$HOME" } );
    |         ----------------------^^^^^^^^^^^^^^^^--------------------------
    |         |                     |                       |
    |         |                     |                       temporary value is freed at the end of this statement
    |         |                     creates a temporary value which is freed while still in use
    |         borrow later used here
    |
    = note: consider using a `let` binding to create a longer lived value
```

The new version compiles both before and after the PR.